### PR TITLE
Citymaps fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
   <link rel="stylesheet" href="%PUBLIC_URL%/css/tigrinya.css" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
   <link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet">
-  <link href="https://ta-media.citymaps.io/lib/v1.0.63/citymaps.css" rel="stylesheet" />
+  <link href="https://ta-media.citymaps.io/lib/v1.0.67/citymaps.css" rel="stylesheet" />
   <link href="%PUBLIC_URL%/css/L.Control.Locate.min.css" rel="stylesheet" />
 
   <!--

--- a/src/components/ServiceMap.js
+++ b/src/components/ServiceMap.js
@@ -120,6 +120,8 @@ class ServiceMap extends React.Component {
 		const map = L.citymaps.map("MapCanvas", null, {
 			scrollWheelZoom: true,
 			zoomControl: true,
+			// Citymaps will automatically select "global" if language is not supported or undefined.
+			language: this.props.i18n.language
 		});
 
 		let clusters = L.markerClusterGroup({

--- a/src/scenes/Services.js
+++ b/src/scenes/Services.js
@@ -341,6 +341,7 @@ class Services extends React.Component {
 								<ServiceMap
 									{...props}
 									goToService={goToService}
+									language={language}
 									locationEnabled={sortingByLocationEnabled && !errorWithGeolocation}
 									measureDistance={this.measureDistance(geolocation, language)}
 									toggleLocation={() => _.identity()}

--- a/src/scenes/Services.js
+++ b/src/scenes/Services.js
@@ -292,6 +292,7 @@ class Services extends React.Component {
 										toggleLocation={() => _.identity()}
 										servicesByType={() => this.fetchAllServicesNearby()}
 										nearby={true}
+									  showMap={() => goToMap()}
 									/>
 								</div>
 							</Skeleton>
@@ -384,6 +385,7 @@ class Services extends React.Component {
 									measureDistance={this.measureDistance(geolocation, language)}
 									toggleLocation={() => this.setState({ sortingByLocationEnabled: true })}
 									servicesByType={() => this.fetchAllInLocation(props.match.params.location)}
+									showMap={() => goToMap()}
 								/>
 							</div>
 						</Skeleton>


### PR DESCRIPTION
Language support has been added. Of the three languages used we only support "Global" and English (not Arabic or Farsi) but Arabic support is coming soon.

Also in some cases the "View Map" button was broken (example: click "Near Me" from the homepage; on the next screen, "View Map" does not work). Fixed by adding showMap callbacks in two places.